### PR TITLE
New Complex Matrix method: eigh

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,19 @@
 
 import PackageDescription
 
+var packageDependencies: [Package.Dependency] = [
+    // Dependencies declare other packages that this package depends on.
+    // .package(url: /* package url */, from: "1.0.0"),
+]
+
+#if os(Linux)
+
+packageDependencies += [
+    .package(url: "https://github.com/indisoluble/CLapacke-Linux", from: "1.0.0"),
+]
+
+#endif
+
 let package = Package(
     name: "qiskit",
     products: [
@@ -13,10 +26,7 @@ let package = Package(
         .executable(
             name: "qiskitexamples", targets: ["examples"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: packageDependencies,
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.

--- a/Sources/qiskit/datastructures/ArrayError.swift
+++ b/Sources/qiskit/datastructures/ArrayError.swift
@@ -35,6 +35,8 @@ public enum ArrayError: LocalizedError, CustomStringConvertible {
     case errorAxis(axis1: Int, axis2: Int)
     case errorAxisForShape(axis1: Int, axis2: Int, shape: [Int])
     case differentSizes(count1: Int, count2: Int)
+    case matrixIsNotHermitian
+    case unableToComputeEigenValues
 
     public var errorDescription: String? {
         return self.description
@@ -71,6 +73,10 @@ public enum ArrayError: LocalizedError, CustomStringConvertible {
             return "Invalid axis \(axis1),\(axis2) for shape \(shape.description)"
         case .differentSizes(let count1, let count2):
             return "Vectors have different sizes: (\(count1),\(count2))"
+        case .matrixIsNotHermitian:
+            return "Matrix is not hermitian"
+        case .unableToComputeEigenValues:
+            return "Unable to compute eigen values for this matrix"
         }
     }
 }

--- a/Sources/qiskit/datastructures/Matrix.swift
+++ b/Sources/qiskit/datastructures/Matrix.swift
@@ -13,6 +13,16 @@
 // limitations under the License.
 // =============================================================================
 
+#if os(OSX) || os(iOS)
+
+    import Accelerate
+
+#elseif os(Linux)
+
+    import CLapacke_Linux
+
+#endif
+
 import Foundation
 
 public struct Matrix<T: NumericType> : Hashable, CustomStringConvertible, ExpressibleByArrayLiteral {
@@ -433,6 +443,10 @@ extension Matrix where T == Complex {
         self.init(value: value)
     }
 
+    public var isHermitian: Bool {
+        return (self == transpose().conjugate())
+    }
+
     public func conjugate() -> Matrix {
         var m = Matrix<T>(repeating: 0, rows: self.rowCount, cols: self.colCount)
         for row in 0..<m.rowCount {
@@ -441,6 +455,74 @@ extension Matrix where T == Complex {
             }
         }
         return m
+    }
+
+    public func eigh() throws -> (Vector<Double>, Matrix<Complex>) {
+        guard isHermitian else {
+            throw ArrayError.matrixIsNotHermitian
+        }
+
+        var jobz = Int8(86) // V: Compute eigenvalues and eigenvectors
+        var uplo = Int8(76) // L: Lower triangular part
+
+        var n = Int32(rowCount)
+        var lda = Int32(rowCount)
+        var info = Int32()
+
+        var w = Array(repeating: Double(), count: rowCount)
+
+        #if os(OSX) || os(iOS)
+
+            var a = flattenCol().map { __CLPK_doublecomplex(r: $0.real, i: $0.imag) }
+
+            // Get optimal workspace
+            var tmpWork = __CLPK_doublecomplex()
+            var lengthTmpWork = Int32(-1)
+            var tmpRWork = Double()
+            var lengthTmpRWork = Int32(-1)
+            var tmpIWork = Int32()
+            var lengthTmpIWork = Int32(-1)
+
+            zheevd_(&jobz, &uplo, &n, &a, &lda, &w, &tmpWork, &lengthTmpWork, &tmpRWork, &lengthTmpRWork, &tmpIWork, &lengthTmpIWork, &info)
+
+            // Compute eigenvalues & eigenvectors
+            var lengthWork = Int32(tmpWork.r)
+            var work = Array(repeating: __CLPK_doublecomplex(), count: Int(lengthWork))
+            var lengthRWork = Int32(tmpRWork)
+            var rWork = Array(repeating: Double(), count: Int(lengthRWork))
+            var lengthIWork = tmpIWork
+            var iWork = Array(repeating: Int32(), count: Int(lengthIWork))
+
+            zheevd_(&jobz, &uplo, &n, &a, &lda, &w, &work, &lengthWork, &rWork, &lengthRWork, &iWork, &lengthIWork, &info)
+
+        #elseif os(Linux)
+
+            var a = flattenCol().value
+            let aPointer =  UnsafeMutablePointer(mutating: a)
+            let aOpaquePointer = OpaquePointer(aPointer)
+
+            info = LAPACKE_zheevd(LAPACK_COL_MAJOR, jobz, uplo, n, aOpaquePointer, lda, &w)
+
+        #endif
+
+        // Validate results
+        if (info > 0) {
+            throw ArrayError.unableToComputeEigenValues
+        }
+
+        #if os(OSX) || os(iOS)
+
+            let aComplex = MultiDArray<Complex>(value: a.map { Complex($0.r, $0.i) })
+
+        #elseif os(Linux)
+
+            let aComplex = MultiDArray<Complex>(value: a)
+
+        #endif
+
+        let vectorsStoredByCol = try aComplex.reshape([rowCount, rowCount]).value as! [[Complex]]
+
+        return (Vector(value: w), Matrix(value: vectorsStoredByCol).transpose())
     }
 
     public func sqrt() -> Matrix {

--- a/Tests/qiskitTests/DataStructureTests.swift
+++ b/Tests/qiskitTests/DataStructureTests.swift
@@ -29,6 +29,7 @@ class DataStructureTests: XCTestCase {
         ("testLongestPath",testLongestPath),
         ("testVector",testVector),
         ("testMatrix",testMatrix),
+        ("testComplexMatrix", testComplexMatrix),
         ("testTrace",testTrace)
     ]
 
@@ -241,6 +242,31 @@ class DataStructureTests: XCTestCase {
         a = [[10,0,3, 6], [-2,-4,1, 9], [3,0,2, 11], [7,8,9, 24]]
         XCTAssertEqual(try a.slice((0,2),(0,2)).description, [[10, 0],[-2, -4]].description)
         XCTAssertEqual(try a.slice((2,4),(2,4)).description, [[2, 11], [9, 24]].description)
+    }
+
+    func testComplexMatrix() {
+        let a: Matrix<Complex> = [[Complex(2, 0), Complex(0, 1), Complex(0, 0)],
+                                  [Complex(0, 1), Complex(2, 0), Complex(0, 0)],
+                                  [Complex(0, 0), Complex(0, 0), Complex(3, 0)]]
+        var b = a
+        b[1, 0] = Complex(0, -1)
+        XCTAssertFalse(a.isHermitian)
+        XCTAssertTrue(b.isHermitian)
+        XCTAssertThrowsError(try a.eigh())
+        let (values, vectors) = try! b.eigh()
+        let expectedValues = Vector(value: [1.0, 3.0, 3.0])
+        let expectedVectors : Matrix<Complex> = [[Complex(-0.7071, 0), Complex(-0.7071, 0), Complex(0, 0)],
+                                                 [Complex(0, -0.7071), Complex(0, 0.7071),  Complex(0, 0)],
+                                                 [Complex(0, 0),       Complex(0, 0),       Complex(1, 0)]]
+        XCTAssertEqual(values, expectedValues)
+        XCTAssertEqual(vectors.rowCount, expectedVectors.rowCount)
+        XCTAssertEqual(vectors.colCount, expectedVectors.colCount)
+        for row in 0..<vectors.rowCount {
+            for col in 0..<vectors.colCount {
+                XCTAssertEqual(vectors[row, col].real, expectedVectors[row, col].real, accuracy: 0.00001)
+                XCTAssertEqual(vectors[row, col].imag, expectedVectors[row, col].imag, accuracy: 0.00001)
+            }
+        }
     }
 
     func testTrace() {


### PR DESCRIPTION
### What
Added new method to Matrix class to compute the eigenvalues and eigenvectors of a hermitian matrix

### Why
In order to plot a *qsphere*, first we need to get the eigenvalues and eigenvectors of the corresponding hermitian state operator.

### How
The new method acts as a wrapper around the method `zheevd` in LAPACK package for macOS/iOS and Linux.

### Related to
* PR [New playground: Visualizing Quantum State](https://github.com/QISKit/qiskit-sdk-swift/pull/3)
* Issue [Enhancement: Add dependency LAPACK](https://github.com/QISKit/qiskit-sdk-swift/issues/4)

Hi @manoelmarques, this PR is not ready to be merged given that, as we already discussed, it introduces a new dependency: [CLapacke-Linux](https://github.com/indisoluble/CLapacke-Linux); but while this situation is resolved, I thought it would be a good idea to push these changes to get some feedback.

