### PR TITLE
Fix bug: MultiDArray(repeating, shape) was not replicating 'repeating' value

### DIFF
--- a/Sources/qiskit/datastructures/MultiDArray.swift
+++ b/Sources/qiskit/datastructures/MultiDArray.swift
@@ -34,7 +34,7 @@ public struct MultiDArray<T: NumericType> : Hashable, CustomStringConvertible, E
         self.shape = shape
         let indexes: [[Int]] = MultiDArray<T>.getAllIndexes(self.shape)
         for index in indexes {
-            self._value[Vector<Int>(value:index)] = 0
+            self._value[Vector<Int>(value:index)] = repeating
         }
     }
 

--- a/Tests/qiskitTests/DataStructureTests.swift
+++ b/Tests/qiskitTests/DataStructureTests.swift
@@ -29,7 +29,8 @@ class DataStructureTests: XCTestCase {
         ("testLongestPath",testLongestPath),
         ("testVector",testVector),
         ("testMatrix",testMatrix),
-        ("testTrace",testTrace)
+        ("testTrace",testTrace),
+        ("testMultiDArray", testMultiDArray)
     ]
 
     override func setUp() {
@@ -258,6 +259,14 @@ class DataStructureTests: XCTestCase {
         } catch let error {
             XCTFail("testTrace: \(error)")
         }
+    }
+
+    func testMultiDArray() {
+        let value = 101
+        let count = 3
+        let a = try! MultiDArray(repeating: value, shape: [count])
+        let b = Array(repeating: value, count: count)
+        XCTAssertEqual(a.value as! [Int], b)
     }
 
     private class func formatList(_ list: [GraphVertex<EmptyGraphData>]) -> String {


### PR DESCRIPTION
 A `MultiDArray` instance created with `MultiDArray(repeating, shape)` did not set all its positions to the specified value but to `0`.