### PR TITLE
Rename "QI Software Kit" to "QI Science Kit"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-Quantum Information Software Kit (QISKit)
-=========================================
+Quantum Information Science Kit (QISKit)
+========================================
 
 Swift software development kit (SDK) for working
 with OpenQASM and the IBM Q experience (QX).


### PR DESCRIPTION
Minor change, as per @jaygambetta indications - this was mostly done by grepping for the relevant string and replacing.