### PR TITLE
qiskitexamples: run examples on remote server & also on local simulator

### DIFF
--- a/Sources/examples/CommandLineHandler.swift
+++ b/Sources/examples/CommandLineHandler.swift
@@ -27,6 +27,7 @@ public final class CommandLineHandler {
         print("Options:")
         print("--help                     Shows usage")
         print("--token <token>            Specifies IBM Quantum Experience Token")
+        print("--local                    Run examples on local simulator")
         print("Input:")
         print("None                       Runs all examples")
         print("ghz|qft|rippleadd|teleport Runs specified example")
@@ -35,56 +36,67 @@ public final class CommandLineHandler {
     public func run() throws {
         guard arguments.count > 1 else {
             CommandLineHandler.printUsage()
-            throw CommandLineError.missingToken
+            throw CommandLineError.missingOption
         }
-        // The first argument is the execution path
+
+        var token: String?
+        var input = "all"
+
         let argument = arguments[1].lowercased()
-        if argument == "--help" {
+        switch argument {
+        case "--help":
             CommandLineHandler.printUsage()
             return
-        }
-        guard argument == "--token" else {
+        case "--local":
+            if arguments.count > 2 {
+                input = arguments[2].lowercased()
+            }
+        case "--token":
+            guard arguments.count > 2 else {
+                CommandLineHandler.printUsage()
+                throw CommandLineError.missingOption
+            }
+            token = arguments[2]
+            
+            if arguments.count > 3 {
+                input = arguments[3].lowercased()
+            }
+        default:
             CommandLineHandler.printUsage()
-            throw CommandLineError.invalidArgument(argument: argument)
+            throw CommandLineError.invalidOption(option: argument)
         }
-        guard arguments.count > 2 else {
-            CommandLineHandler.printUsage()
-            throw CommandLineError.missingToken
-        }
-        let token = arguments[2]
-        var option: String = "all"
-        if arguments.count > 3 {
-            option = arguments[3].lowercased()
-        }
-        switch option {
+
+        let option = CommandLineOption(apiToken: token)
+
+        switch input {
             case "ghz":
-                GHZ.ghz(token) {
+                GHZ.ghz(option) {
                     print("*** Finished ***")
                     exit(0)
                 }
             case "qft":
-                QFT.qft(token) {
+                QFT.qft(option) {
                     print("*** Finished ***")
                     exit(0)
                 }
             case "rippleadd":
-                RippleAdd.rippleAdd(token) {
+                RippleAdd.rippleAdd(option) {
                     print("*** Finished ***")
                     exit(0)
                 }
             case "teleport":
-                Teleport.teleport(token) {
+                Teleport.teleport(option) {
                     print("*** Finished ***")
                     exit(0)
                 }
             case "all":
-                GHZ.ghz(token) {
+                GHZ.ghz(option) {
                     print("*** Finished ***")
-                    QFT.qft(token) {
+                    QFT.qft(option) {
                         print("*** Finished ***")
-                        RippleAdd.rippleAdd(token) {
+                        RippleAdd.rippleAdd(option) {
                             print("*** Finished ***")
-                            Teleport.teleport(token) {
+                            Teleport.teleport(option) {
                                 print("*** Finished ***")
                                 exit(0)
                             }
@@ -93,7 +105,7 @@ public final class CommandLineHandler {
                 }
             default:
                 CommandLineHandler.printUsage()
-                throw CommandLineError.invalidOption(option: option)
+                throw CommandLineError.invalidInput(input: input)
         }
         RunLoop.main.run()
     }

--- a/Sources/examples/CommandLineOption.swift
+++ b/Sources/examples/CommandLineOption.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 IBM RESEARCH. All Rights Reserved.
+// Copyright 2018 IBM RESEARCH. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,25 +16,15 @@
 import Foundation
 
 /**
- Command Line Exceptions
+ Command Line Option
  */
-public enum CommandLineError: LocalizedError, CustomStringConvertible {
+public struct CommandLineOption {
 
-    case missingOption
-    case invalidOption(option: String)
-    case invalidInput(input: String)
+    enum Backend: String {
+        case ibmqx2 = "ibmqx2"
+        case ibmqxQasmSimulator = "ibmqx_qasm_simulator"
+        case localQasmSimulator = "local_qasm_simulator"
+    }
 
-    public var errorDescription: String? {
-        return self.description
-    }
-    public var description: String {
-        switch self {
-        case .missingOption:
-            return "Missing option."
-        case .invalidOption(let option):
-            return "Invalid option \(option)."
-        case .invalidInput(let input):
-            return "Invalid input \(input)."
-        }
-    }
+    let apiToken: String?
 }


### PR DESCRIPTION
### What
`qiskitexamples` mostly run the examples on **IBM Quantum Experience** remote simulator and `ibmqx2`. With the changes in this PR, we can also run the examples on the local simulator in our computer.

### Why
As mentioned in issue #8, I am working with the owners of the QISKit SDK Python project to deploy the C++ QASM simulator as a Debian package. Once this is done, I would like to prepare a new PR to make use of this simulator in the Swift framework and then, I will need a way to show it is working as expected. My intention is to modify `qiskitexamples` to let the user decide which local simulator he/she wants to use.

### How
`qiskitexamples` now exposes a new option: `--local`

```
Usage: qiskitexamples [options] [input]
Options:
--help                     Shows usage
--token <token>            Specifies IBM Quantum Experience Token
--local                    Run examples on local simulator
Input:
None                       Runs all examples
ghz|qft|rippleadd|teleport Runs specified example
```

If instead of `--token <token>`, you specify `--local`; the program will not try to connect to the server, instead it will run the test on your local simulator (backend `local_qasm_simulator`).

Of all the changes the most interesting is the new class I have introduced named `CommandLineOption`. It holds the `token` (in case there is any) and defines an enumerated typed with the different backends the program uses. At this moment, it might not seem specially useful but, later on, when we can choose between the current local simulator and the C++ QASM simulator, I intend to limit to this class the necessary changes to allow this functionality; the resulting code should be cleaner (or at least, I hope so :) )